### PR TITLE
Inject CLIENT_ID at build time instead of hardcoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to `.env` and fill in your GitHub OAuth App's Client ID.
+#
+# Create an OAuth App at: https://github.com/settings/developers
+#   → New OAuth App → enable "Device Flow"
+#   → copy the Client ID (starts with "Ov23li...")
+#
+# The value is injected into the build by esbuild (see esbuild.config.mjs);
+# `.env` itself is git-ignored and never committed.
+#
+# In CI, set CLIENT_ID as a repository secret instead of using this file
+# (see .github/workflows/release.yml).
+
+CLIENT_ID=Ov23liYOUR_CLIENT_ID

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ main.js
 *.js.map
 dist/
 .env
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+An Obsidian community plugin ("Git Sync") that syncs a vault across devices by committing it to the user's own private GitHub repo. Runs on desktop **and** mobile (iOS/Android), so all git and HTTP work goes through pure-JS/Obsidian APIs — no native binaries, no Node `fs`, no `fetch`.
+
+## Commands
+
+```bash
+npm install
+npm run dev      # esbuild watch mode — rebuilds main.js on save (inline sourcemaps)
+npm run build    # production build — minified, no sourcemaps
+```
+
+There is **no test suite, linter, or typecheck script**. `tsconfig.json` is used by esbuild for transpile only (`isolatedModules`, no `tsc` emit step). Verify changes by loading the built `main.js` in an Obsidian vault.
+
+The build entry is `src/main.ts` → bundled to `main.js` (git-ignored). To test in Obsidian, copy/symlink `main.js` + `manifest.json` into `<vault>/.obsidian/plugins/git-obsi-sync/`.
+
+Releases are tag-triggered: pushing a git tag runs `.github/workflows/release.yml`, which builds and attaches `main.js` + `manifest.json` to a GitHub Release.
+
+## Hard mobile constraints (do not break these)
+
+- **All HTTP must use Obsidian's `requestUrl`** (from the `obsidian` module), never `fetch`/`axios`. This is what makes mobile + CORS work. See `src/github/api.ts`, `src/auth/github-device.ts`, and the custom `gitHttp` client in `src/sync/git-sync.ts`.
+- **All filesystem access must go through the Obsidian `DataAdapter`**, never Node `fs`. `src/sync/fs-adapter.ts` wraps the adapter into the `fs.promises`-shaped object isomorphic-git expects, and is the *only* place that bridges the two worlds.
+- `esbuild.config.mjs` marks `obsidian`, `electron`, all `@codemirror/*`/`@lezer/*`, and Node builtins as `external` — don't import anything that pulls a Node builtin into the runtime path.
+
+## Architecture
+
+Layered, with `main.ts` (the `Plugin` subclass) as the only orchestrator. Lower layers never import `main.ts` or touch Obsidian settings.
+
+- **`src/main.ts`** — plugin lifecycle. Registers vault `modify`/`create`/`delete`/`rename` events → `SyncQueue`; pulls on `onLayoutReady`; flushes the queue on `onunload`; owns the connect/disconnect flow and conflict-modal wiring. `isExcluded()` compiles the user's glob-ish `excludePatterns` (only `*` is special) to regex.
+- **`src/sync/git-sync.ts`** — `GitSync`, the isomorphic-git wrapper. Owns the full sync cycle: stage → commit-if-dirty → fetch → merge → detect conflicts → push. Every step is individually try/guarded so one failure (e.g. offline fetch) doesn't cascade. `gitOpts()` vs `netOpts()` split matters: network ops need `onAuth` (isomorphic-git strips creds from the URL) and an explicit `url`.
+- **`src/sync/queue.ts`** — `SyncQueue`. Debounces file events (`SYNC_DEBOUNCE_MS`, 3s), coalesces into a `Set`, runs one sync at a time (`running` guard), and re-flushes if changes arrived mid-sync.
+- **`src/sync/fs-adapter.ts`** — the Obsidian-adapter → isomorphic-git `fs` bridge. isomorphic-git passes **absolute** paths; `rel()` strips the vault base path before calling the adapter (which wants relative paths). On mobile `basePath` is undefined, so paths stay relative.
+- **`src/sync/conflict.ts`** — pure line-diff helper for the conflict modal.
+- **`src/auth/github-device.ts`** — GitHub OAuth **Device Flow** (no backend server): request a device code, poll the token endpoint honoring `authorization_pending`/`slow_down`.
+- **`src/github/api.ts`** — REST calls: get user, check/create the private repo, derive repo name (`obsidian-<slugified-vault-name>`).
+- **`src/ui/`** — `settings-tab.ts` (connect flow + options), `status-bar.ts` (clickable status → manual sync), `conflict-modal.ts` (side-by-side keep-mine/keep-theirs).
+
+### Sync-state model to keep in mind
+
+Three distinct states, checked in `initializeRepo` and throughout `GitSync`:
+1. `isInitialized()` — local `.git` with a resolvable `HEAD`.
+2. `hasLocalBranch()` — `refs/heads/main` exists (≥1 commit; distinguishes an unborn branch after `git.init`).
+3. remote existence (`repoExists`) and remote emptiness (`clone()` returns `false` when the remote has no commits).
+
+The initial-push/clone/reconnect branching in `initializeRepo` and the retry-safety in `initAndPush` exist to handle interrupted first pushes (repo created but never pushed). Preserve these guards when editing.
+
+`DEFAULT_BRANCH` is `"main"` and the code assumes a single branch everywhere (`singleBranch: true`). There is no rebase — merges are real merge commits via `git.merge`.
+
+## Gotchas
+
+- **CLIENT_ID is injected at build time, not hardcoded.** `esbuild.config.mjs` loads `.env` via `dotenv` and injects `CLIENT_ID` into the bundle with a `define` for `process.env.CLIENT_ID`; `src/constants.ts` reads `process.env.CLIENT_ID`. A real exported env var (CI secret) wins over `.env`. A **production** build (`npm run build`) fails fast if `CLIENT_ID` is empty; a **dev** build (`npm run dev`) is allowed to run without it. To change the OAuth app, edit `.env` (local) or the CI secret — never hardcode it in source. The authorization screen's app name/owner is determined entirely by this `CLIENT_ID`.
+- **Naming is inconsistent.** `package.json`/`PLUGIN_ID`/esbuild banner say `obsidian-multisync`; `manifest.json` id is `git-obsi-sync` (this is the folder name Obsidian uses under `.obsidian/plugins/`, and it must match the manifest id or the plugin fails to load). User-facing name is "Git Sync". Don't "fix" one without checking the others.
+- `excludePatterns` matching supports only `*` as a wildcard (converted to `.*`), anchored full-match — not full glob. Default excludes `.obsidian/workspace*` and per-plugin `data.json`.

--- a/README.md
+++ b/README.md
@@ -74,13 +74,18 @@ npm install
 This installs:
 - `isomorphic-git` — pure-JS git engine (works on mobile, no native binaries)
 - `esbuild` — fast bundler
-- `typescript` — type checker
+- `dotenv` — loads `CLIENT_ID` from `.env` at build time
+- `typescript` — type definitions / optional type checking (not part of the build)
 - `obsidian` — type definitions only (not bundled)
 
 ### 1.3 — Register a GitHub OAuth App
 
 You need to register a free OAuth App so users can log in with their GitHub account.
-This is done **once** — the `client_id` is then baked into the plugin code.
+This is done **once** — the Client ID is stored in a local `.env` file and injected
+into the build by esbuild (see `esbuild.config.mjs`). It is never hardcoded in source.
+
+> Make sure to enable **Device Flow** on the OAuth App — this plugin authenticates
+> via the Device Flow and will not work without it.
 
 1. Go to [github.com/settings/developers](https://github.com/settings/developers)
 2. Click **OAuth Apps** → **New OAuth App**
@@ -88,9 +93,13 @@ This is done **once** — the `client_id` is then baked into the plugin code.
 
    | Field | Value |
    |---|---|
-   | Application name | `GitHub Vault Sync` |
+   | Application name | `Obsidian Vault Sync` *(any name — see note below)* |
    | Homepage URL | `https://github.com/livan116/github-valut-sync` |
    | Authorization callback URL | `https://obsidian.md` *(placeholder — Device Flow doesn't use this)* |
+
+   > The **application name is purely a display label** shown on the GitHub
+   > authorization screen — nothing in the plugin references it, so pick anything you like.
+   > Note: GitHub **rejects names containing "GitHub"**, so don't start it with that word.
 
 4. Click **Register application**
 5. Copy the **Client ID** (looks like `Ov23li...`)
@@ -111,9 +120,17 @@ npm run dev
 npm run build
 ```
 
-Both commands output a single `main.js` file in the project root.
+Both commands output a single `main.js` file in the project root. At build time
+esbuild reads `CLIENT_ID` (from `.env`, or from a real environment variable if set)
+and injects it into the bundle. A **production** build (`npm run build`) fails fast
+with an error if `CLIENT_ID` is missing; a **dev** build (`npm run dev`) still runs so
+you can work on non-auth features.
 
 **Watch mode** (`npm run dev`) keeps running and rebuilds automatically as you edit source files. Leave it running while you test in Obsidian.
+
+> **CI / releases:** the GitHub Actions release workflow sets `CLIENT_ID` from a
+> repository secret (not from `.env`, which is git-ignored). An exported environment
+> variable always takes precedence over the `.env` file.
 
 ### 1.5 — Project Structure
 
@@ -122,7 +139,7 @@ github-valut-sync/
 ├── src/
 │   ├── main.ts                   # Plugin entry point — wires everything together
 │   ├── types.ts                  # All TypeScript interfaces & types
-│   ├── constants.ts              # App-wide constants (CLIENT_ID injected here at build)
+│   ├── constants.ts              # App-wide constants (reads CLIENT_ID from process.env, set by esbuild define)
 │   ├── auth/
 │   │   └── github-device.ts      # GitHub OAuth Device Flow (no server needed)
 │   ├── github/
@@ -155,7 +172,7 @@ After running `npm run build`:
 
 1. Create the plugin folder inside your vault:
    ```
-   YourVault/.obsidian/plugins/github-vault-sync/
+   YourVault/.obsidian/plugins/git-obsi-sync/
    ```
 2. Copy these two files into that folder:
    ```
@@ -164,16 +181,16 @@ After running `npm run build`:
    ```
 3. Open Obsidian → **Settings** → **Community plugins**
 4. Turn off **Restricted Mode** if prompted
-5. Find **GitHub Vault Sync** in the list → toggle it **ON**
+5. Find **Git Sync** in the list → toggle it **ON**
 
 **Tip for development:** You can symlink the project directory directly into your vault's plugins folder so the built `main.js` is picked up automatically after each build:
 
 ```bash
 # Windows (run as Administrator)
-mklink /D "C:\path\to\vault\.obsidian\plugins\github-vault-sync" "C:\path\to\github-valut-sync"
+mklink /D "C:\path\to\vault\.obsidian\plugins\git-obsi-sync" "C:\path\to\github-valut-sync"
 
 # macOS / Linux
-ln -s /path/to/github-valut-sync /path/to/vault/.obsidian/plugins/github-vault-sync
+ln -s /path/to/github-valut-sync /path/to/vault/.obsidian/plugins/git-obsi-sync
 ```
 
 ### Option B — BRAT (Beta Testers)
@@ -191,7 +208,7 @@ ln -s /path/to/github-valut-sync /path/to/vault/.obsidian/plugins/github-vault-s
 
 ### Step 1 — Open Plugin Settings
 
-Go to **Settings** → **GitHub Vault Sync** (scroll down in the left sidebar under Community Plugins).
+Go to **Settings** → **Git Sync** (scroll down in the left sidebar under Community Plugins).
 
 ### Step 2 — Click "Connect GitHub"
 
@@ -262,7 +279,7 @@ Click the status bar item to trigger an **immediate manual sync** at any time.
 ### Manual Sync
 
 - Click the status bar item, **or**
-- Open the Command Palette (`Ctrl/Cmd + P`) → search **"MultiSync: Sync vault now"**
+- Open the Command Palette (`Ctrl/Cmd + P`) → search **"Sync vault now"**
 
 ---
 
@@ -313,7 +330,7 @@ Vault: "Research"         →  github.com/you/obsidian-research
 
 On each device:
 1. Open the vault in Obsidian.
-2. Go to **Settings → GitHub Vault Sync** → connect your GitHub account.
+2. Go to **Settings → Git Sync** → connect your GitHub account.
 3. The plugin detects which vault is open and connects to the right repo automatically.
 
 ---
@@ -336,7 +353,7 @@ On each device:
 
 These are excluded because they change frequently, are device-specific, and don't need to be shared.
 
-To add more exclusions, open **Settings → GitHub Vault Sync → Excluded patterns** and add one pattern per line. Wildcards (`*`) are supported.
+To add more exclusions, open **Settings → Git Sync → Excluded patterns** and add one pattern per line. Wildcards (`*`) are supported.
 
 Example — exclude all files in a `Private` folder:
 ```
@@ -355,7 +372,7 @@ You clicked **Cancel** on the GitHub authorization page. Click **Connect GitHub*
 
 ### Sync shows `✗ Sync Error`
 1. Check your internet connection.
-2. Open **Settings → GitHub Vault Sync** — if disconnected, click **Connect GitHub** to re-authenticate.
+2. Open **Settings → Git Sync** — if disconnected, click **Connect GitHub** to re-authenticate.
 3. GitHub tokens occasionally expire — reconnecting issues a fresh token.
 
 ### Files not appearing on second device
@@ -413,7 +430,7 @@ A: The `repo` scope is the minimum required to create and push to **private** re
 
 ## Privacy & Security
 
-- Your GitHub **access token** is stored only in Obsidian's local plugin data folder (`.obsidian/plugins/github-vault-sync/data.json`) on each device. It never leaves your device except to communicate directly with GitHub's API.
+- Your GitHub **access token** is stored only in Obsidian's local plugin data folder (`.obsidian/plugins/git-obsi-sync/data.json`) on each device. It never leaves your device except to communicate directly with GitHub's API.
 - The plugin requests only the **`repo` scope** — the minimum required to create and access private repositories.
 - To revoke access at any time: GitHub → Settings → Applications → Authorized OAuth Apps → **Revoke**.
 

--- a/buffer-shim.mjs
+++ b/buffer-shim.mjs
@@ -1,0 +1,10 @@
+// Mobile (iOS/Android) has no Node `buffer` builtin and no `Buffer` global.
+// isomorphic-git's deps (readable-stream, sha.js, pako, crc-32) require both.
+// esbuild injects this into every module so `Buffer` resolves at runtime.
+import { Buffer } from "buffer";
+
+if (typeof globalThis.Buffer === "undefined") {
+  globalThis.Buffer = Buffer;
+}
+
+export { Buffer };

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,12 +1,29 @@
 import esbuild from "esbuild";
 import process from "process";
 import { builtinModules } from "module";
+import dotenv from "dotenv";
 
 const prod = process.argv[2] === "production";
+
+// Load .env into process.env (existing env vars, e.g. CI secrets, win).
+dotenv.config();
+
+const clientId = process.env.CLIENT_ID ?? "";
+
+if (prod && !clientId) {
+  console.error(
+    "\nERROR: CLIENT_ID is not set. Create a .env file (see .env.example) " +
+      "or export CLIENT_ID before running a production build.\n"
+  );
+  process.exit(1);
+}
 
 esbuild.build({
   banner: { js: "/* obsidian-multisync */" },
   entryPoints: ["src/main.ts"],
+  define: {
+    "process.env.CLIENT_ID": JSON.stringify(clientId),
+  },
   bundle: true,
   external: [
     "obsidian",

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,6 +10,11 @@ dotenv.config();
 
 const clientId = process.env.CLIENT_ID ?? "";
 
+// Keep Node builtins external (Electron provides them on desktop) EXCEPT
+// `buffer`: mobile has no Node runtime, so `buffer` must be bundled from the
+// npm polyfill and `Buffer` injected as a global. See buffer-shim.mjs.
+const externalBuiltins = builtinModules.filter((m) => m !== "buffer");
+
 if (prod && !clientId) {
   console.error(
     "\nERROR: CLIENT_ID is not set. Create a .env file (see .env.example) " +
@@ -39,8 +44,9 @@ esbuild.build({
     "@lezer/common",
     "@lezer/highlight",
     "@lezer/lr",
-    ...builtinModules,
+    ...externalBuiltins,
   ],
+  inject: ["buffer-shim.mjs"],
   format: "cjs",
   target: "es2018",
   logLevel: "info",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "git-obsi-sync",
   "name": "Git Sync",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minAppVersion": "1.0.1",
   "description": "Sync your vault across all devices using your own GitHub account. Free forever.",
   "author": "Livan Kumar",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "obsidian-multisync",
       "version": "1.0.0",
       "dependencies": {
+        "buffer": "^6.0.3",
         "isomorphic-git": "^1.25.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "dotenv": "^17.4.2",
         "esbuild": "^0.20.0",
         "obsidian": "latest",
         "tslib": "^2.6.0",
@@ -666,6 +667,19 @@
       "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
       "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-"esbuild": "^0.20.0",
+    "dotenv": "^17.4.2",
+    "esbuild": "^0.20.0",
     "obsidian": "latest",
     "tslib": "^2.6.0",
     "typescript": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "node esbuild.config.mjs production"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "isomorphic-git": "^1.25.0"
   },
   "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,6 @@
-export const CLIENT_ID = "Ov23liN8a7D1bDe2571X";
+// Injected at build time by esbuild's `define` from .env (or CI secret).
+// See esbuild.config.mjs and .env.example.
+export const CLIENT_ID = process.env.CLIENT_ID ?? "";
 
 export const GITHUB_DEVICE_URL = "https://github.com/login/device/code";
 export const GITHUB_TOKEN_URL  = "https://github.com/login/oauth/access_token";


### PR DESCRIPTION
Current build still keeps using the client ID of livan116's application, open this PR to better support reading custom clientID from the user. Also update the README to sync with the Obsidian plugin folder name and use the up-to-date names

Move the OAuth CLIENT_ID out of source: constants.ts now reads it from process.env, and esbuild injects it via a define from .env (or a CI secret, which takes precedence). Production builds fail fast when it's missing; dev builds still run for non-auth work.

Add dotenv devDependency and .env.example, and update the README for the new build flow and the current plugin name/id (git-obsi-sync / Git Sync).